### PR TITLE
Event inspector plugin

### DIFF
--- a/addons/event_system_plugin/core/event_inspector.gd
+++ b/addons/event_system_plugin/core/event_inspector.gd
@@ -1,0 +1,27 @@
+extends EditorInspectorPlugin
+
+const InspectorTools = preload("res://addons/event_system_plugin/core/inspector_tools.gd")
+
+class EventInfo extends VBoxContainer:
+	func _init():
+		pass
+	pass
+
+var EventClass = load("res://addons/event_system_plugin/resources/event_class/event_class.gd")
+
+var editor_gui:Control
+
+func can_handle(object: Object) -> bool:
+	return object is EventClass
+
+
+func parse_category(object: Object, category: String) -> void:
+	if category == "Script Variables":
+		var category_node := InspectorTools.InspectorCategory.new()
+		category_node.label = "Event [%s]"%str(object.get("event_name"))
+		category_node.bg_color = object.get("event_color") as Color
+		category_node.bg_color.a = 0.4
+		category_node.hint_tooltip = object.get("event_hint")
+		add_custom_control(category_node)
+		
+		var event_info 

--- a/addons/event_system_plugin/core/event_inspector.gd
+++ b/addons/event_system_plugin/core/event_inspector.gd
@@ -24,4 +24,12 @@ func parse_category(object: Object, category: String) -> void:
 		category_node.hint_tooltip = object.get("event_hint")
 		add_custom_control(category_node)
 		
-		var event_info 
+		var event_info
+
+
+func parse_property(object: Object, type: int, path: String, hint: int, hint_text: String, usage: int) -> bool:
+	var path_ignore = path+"_ignore"
+	if (path_ignore in object):
+		return true
+	
+	return false

--- a/addons/event_system_plugin/core/inspector_tools.gd
+++ b/addons/event_system_plugin/core/inspector_tools.gd
@@ -1,0 +1,56 @@
+tool
+extends EditorInspector
+
+class InspectorCategory extends Control:
+	var icon:Texture
+	var label:String
+	var bg_color:Color = Color.black
+	
+	func _draw() -> void:
+		draw_rect(Rect2(Vector2(), rect_size), bg_color)
+		
+		var font:Font = get_font("font", "Tree")
+		
+		var hs:int = get_constant("hseparation", "Tree");
+		var w:int = font.get_string_size(label).x;
+		if (icon):
+			w += hs + icon.get_width();
+		
+		var ofs:int = (rect_size.x - w) / 2
+		
+		if (icon):
+			draw_texture(icon, Vector2(ofs, (rect_size.y - icon.get_height()) / 2).floor())
+			ofs += hs + icon.get_width();
+		
+		var color:Color = get_color("font_color", "Tree")
+		draw_string(font, Vector2(ofs, font.get_ascent() + (rect_size.y - font.get_height()) / 2).floor(), label, color, rect_size.x);
+	
+	func _get_minimum_size() -> Vector2:
+		var font:Font = get_font("font", "Tree")
+
+		var ms:Vector2 = Vector2()
+		ms.x = 1;
+		ms.y = font.get_height()
+		if icon:
+			ms.y = max(icon.get_height(), ms.y);
+		ms.y += get_constant("vseparation", "Tree");
+
+		return ms;
+	
+	func _ready() -> void:
+		var parent = get_parent()
+		if is_instance_valid(parent):
+			if get_position_in_parent() != 0:
+				var category := parent.get_child(get_position_in_parent()-1) as Control
+				category.hide()
+		
+		if icon == null:
+			icon = get_icon("Object", "EditorIcons")
+			update()
+		
+		if bg_color == Color.black:
+			bg_color = get_color("prop_category", "Editor")
+			update()
+
+func get_category_instance() -> InspectorCategory:
+	return InspectorCategory.new()

--- a/addons/event_system_plugin/plugin_script.gd
+++ b/addons/event_system_plugin/plugin_script.gd
@@ -17,6 +17,8 @@ var _version_button:BaseButton
 
 var _plugin_data:ConfigFile = ConfigFile.new()
 
+var event_inspector:EditorInspectorPlugin
+
 
 func _init() -> void:
 	name = PLUGIN_NAME.capitalize()
@@ -36,6 +38,9 @@ func _enter_tree() -> void:
 	_dock_button = add_control_to_bottom_panel(_timeline_editor, "TimelineEditor")
 	_dock_button.visible = false
 	_add_version_button()
+	
+	event_inspector = load("res://addons/event_system_plugin/core/event_inspector.gd").new()
+	add_inspector_plugin(event_inspector)
 
 
 func enable_plugin() -> void:
@@ -74,6 +79,7 @@ func _exit_tree() -> void:
 	if is_instance_valid(_timeline_editor):
 		remove_control_from_bottom_panel(_timeline_editor)
 		_timeline_editor.queue_free()
+	remove_inspector_plugin(event_inspector)
 
 
 func _show_welcome() -> void:


### PR DESCRIPTION
Adding an inspector plugin to events let the plugin customize the view in the Godot's inspector.
![image](https://user-images.githubusercontent.com/7025991/144508791-43baa115-29fb-4496-a933-c80e2c67e11d.png)
