### PR TITLE
Unlock the full power of wait timer by removing arbitrary limitations (60 seconds only, 1 second step only)

### DIFF
--- a/addons/event_system_plugin/events/wait.gd
+++ b/addons/event_system_plugin/events/wait.gd
@@ -2,7 +2,7 @@ tool
 extends Event
 class_name EventWait
 
-export(float, 0, 60, 1) var wait_time = 0.0 setget set_wait_time
+export(float) var wait_time = 0.0 setget set_wait_time
 
 func _init():
 	event_name = "Wait"


### PR DESCRIPTION
makes wait event not completely useless by allowing any float value