### PR TITLE
Make call_deferred a normal call for saving

### DIFF
--- a/addons/event_system_plugin/plugin_script.gd
+++ b/addons/event_system_plugin/plugin_script.gd
@@ -76,7 +76,7 @@ func make_visible(visible: bool) -> void:
 
 func save_external_data() -> void:
 	if is_instance_valid(_timeline_editor):
-		_timeline_editor.call_deferred("_update_values")
+		_timeline_editor.call("_update_values")
 
 
 func register_event(event:Script) -> void:


### PR DESCRIPTION
In theory, the issue occurs because of a botched call stack due to _update_values being a deferred call, making the engine and resource system really confused.
Doesn't close #23, testing confirmed the bug is still present even with this change-  might have something to do with emit_changed() instead.