### PR TITLE
Fix failed saves in condition event subresources

### DIFF
--- a/addons/event_system_plugin/events/condition.gd
+++ b/addons/event_system_plugin/events/condition.gd
@@ -5,8 +5,8 @@ class_name EventCondition
 const _Utils = preload("res://addons/event_system_plugin/core/utils.gd")
 
 export(String) var condition:String = "" setget set_condition
-export(Resource) var events_if = Timeline.new()
-export(Resource) var events_else = Timeline.new()
+export(Resource) var events_if = Timeline.new() setget set_if_events
+export(Resource) var events_else = Timeline.new() setget set_else_events
 
 
 func _init() -> void:
@@ -64,13 +64,26 @@ func set_condition(value:String) -> void:
 
 
 func set_if_events(value:Timeline) -> void:
+	if events_if.is_connected("changed", self, "timeline_changed"):
+		events_if.disconnect("changed", self, "timeline_changed")
 	events_if = value
+	if not events_if.is_connected("changed", self, "timeline_changed"):
+		events_if.connect("changed", self, "timeline_changed")
 	emit_changed()
 	property_list_changed_notify()
 
 
 func set_else_events(value:Timeline) -> void:
+	if events_else.is_connected("changed", self, "timeline_changed"):
+		events_else.disconnect("changed", self, "timeline_changed")
 	events_else = value
+	if not events_else.is_connected("changed", self, "timeline_changed"):
+		events_else.connect("changed", self, "timeline_changed")
+	emit_changed()
+	property_list_changed_notify()
+
+
+func timeline_changed() -> void:
 	emit_changed()
 	property_list_changed_notify()
 

--- a/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
+++ b/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
@@ -19,17 +19,22 @@ func initialize() -> void:
 	_event_queue = get_events()
 
 
+func event_changed() -> void:
+	emit_changed()
+	property_list_changed_notify()
+
+
 func set_events(events:Array) -> void:
 	for item in _events:
 		item = item as Resource
 		if item == null:
 			continue
-		if item.is_connected("changed", self, "emit_changed"):
-			item.disconnect("changed", self, "emit_changed")
+		if item.is_connected("changed", self, "event_changed"):
+			item.disconnect("changed", self, "event_changed")
 	for item in events:
 		item = item as Resource
-		if not item.is_connected("changed", self, "emit_changed"):
-			item.connect("changed", self, "emit_changed")
+		if not item.is_connected("changed", self, "event_changed"):
+			item.connect("changed", self, "event_changed")
 	_events = events.duplicate()
 	emit_changed()
 	property_list_changed_notify()
@@ -40,15 +45,15 @@ func add_event(event, at_position=-1) -> void:
 		_events.insert(at_position, event)
 	else:
 		_events.append(event)
-	if not event.is_connected("changed", self, "emit_changed"):
-		event.connect("changed", self, "emit_changed")
+	if not event.is_connected("changed", self, "event_changed"):
+		event.connect("changed", self, "event_changed")
 	emit_changed()
 
 
 func erase_event(event) -> void:
 	_events.erase(event)
-	if event.is_connected("changed", self, "emit_changed"):
-		event.disconnect("changed", self, "emit_changed")
+	if event.is_connected("changed", self, "event_changed"):
+		event.disconnect("changed", self, "event_changed")
 	emit_changed()
 
 


### PR DESCRIPTION
Fix events failing to save when edited in timeline unless a new event was created/removed
Fix conditional event failing to save subresources unless main timeline is saved

Partially fixes issue 23