### PR TITLE
New event behaviour

### DIFF
--- a/addons/event_system_plugin/nodes/event_manager/event_manager.gd
+++ b/addons/event_system_plugin/nodes/event_manager/event_manager.gd
@@ -14,6 +14,7 @@ export(NodePath) var event_node_path:NodePath = "."
 export(bool) var start_on_ready:bool = false
 
 var timeline
+var current_event
 
 func _ready() -> void:
 	if Engine.editor_hint:
@@ -31,22 +32,22 @@ func start_timeline(timeline_resource:Timeline=timeline) -> void:
 		_notify_timeline_end()
 		return
 	
-	if timeline._event_queue.empty():
-		timeline.initialize()
-	
 	go_to_next_event()
 
 
 func go_to_next_event() -> void:
+	var event
+	if not current_event:
+		if not timeline:
+			_notify_timeline_end()
+			return
+		event = timeline.get("event/0")
+	else:
+		event = current_event.get("next_event")
+		if not event:
+			_notify_timeline_end()
 	
-	if timeline == null:
-		_notify_timeline_end()
-		return
-	
-	var event = timeline.get_next_event()
-	
-	if event == null:
-		_notify_timeline_end()
+	current_event = event
 	
 	_execute_event(event)
 
@@ -65,9 +66,9 @@ func _execute_event(event:Event) -> void:
 
 func _connect_event_signals(event:Event) -> void:
 	if not event.is_connected("event_started", self, "_on_Event_started"):
-		event.connect("event_started", self, "_on_Event_started")
+		event.connect("event_started", self, "_on_Event_started", [], CONNECT_ONESHOT)
 	if not event.is_connected("event_finished", self, "_on_Event_finished"):
-		event.connect("event_finished", self, "_on_Event_finished")
+		event.connect("event_finished", self, "_on_Event_finished", [], CONNECT_ONESHOT)
 
 
 func _on_Event_started(event:Event) -> void:

--- a/addons/event_system_plugin/resources/event_class/event_class.gd
+++ b/addons/event_system_plugin/resources/event_class/event_class.gd
@@ -28,6 +28,7 @@ export(bool) var continue_at_end:bool = true setget _set_continue
 
 
 var event_node:Node
+var next_event:Resource
 
 ##########
 # Event Editor Properties

--- a/addons/event_system_plugin/resources/event_class/event_class.gd
+++ b/addons/event_system_plugin/resources/event_class/event_class.gd
@@ -28,7 +28,7 @@ export(bool) var continue_at_end:bool = true setget _set_continue
 
 
 var event_node:Node
-var next_event:Resource
+var next_event:Resource setget set_next_event, get_next_event
 
 ##########
 # Event Editor Properties
@@ -74,6 +74,14 @@ func finish() -> void:
 
 func _execute() -> void:
 	finish()
+
+func set_next_event(event:Resource) -> void:
+	next_event = event
+	emit_changed()
+
+
+func get_next_event() -> Resource:
+	return next_event
 
 
 func get_event_name() -> String:

--- a/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
+++ b/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
@@ -6,7 +6,9 @@ class_name Timeline, "res://addons/event_system_plugin/assets/icons/timeline_ico
 #	- EventManager node
 #	- Event
 
+# deprecated
 var last_event = null
+# deprecated
 var next_event = null
 var _curr_evnt_idx:int = -1
 
@@ -67,32 +69,25 @@ func get_events() -> Array:
 
 
 func get_next_event() -> Resource:
-	_curr_evnt_idx += 1
-	_update_last_n_next_events()
-	return _event_queue.pop_front()
+	push_warning("Timeline.get_next_event() is deprecated and will be removed in future versions")
+#	_curr_evnt_idx += 1
+#	_update_last_n_next_events()
+#	return _event_queue.pop_front()
+	return null
 
 
 func can_loop() -> bool:
 	return _can_loop
 
 
+# Deprecated
 func get_previous_event() -> Resource:
 	return null
 
 
+# Deprecated
 func _update_last_n_next_events() -> void:
-	var _l_evnt_idx = _curr_evnt_idx-1
-	var _n_evnt_idx = _curr_evnt_idx+1
-	
-	if _l_evnt_idx >= 0 and _l_evnt_idx < _events.size():
-		last_event = _events[_l_evnt_idx]
-	else:
-		last_event = null
-	
-	if _n_evnt_idx >= 0 and _n_evnt_idx < _events.size():
-		next_event = _events[_n_evnt_idx]
-	else:
-		next_event = null
+	return
 
 
 func _init() -> void:

--- a/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
+++ b/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
@@ -5,39 +5,41 @@ class_name Timeline, "res://addons/event_system_plugin/assets/icons/timeline_ico
 # Can't reference:
 #	- EventManager node
 #	- Event
+# Note for future devs: Keep this resource as an event container. No magic tricks
 
 # deprecated
 var last_event = null
 # deprecated
 var next_event = null
+
+# deprecated
 var _curr_evnt_idx:int = -1
 
 var _events:Array = [] setget set_events
+
+# deprecated
 var _event_queue:Array = []
+# deprecated
 var _can_loop:bool = false setget ,can_loop
 
 
+# deprecated
 func initialize() -> void:
-	_event_queue = get_events()
+	push_warning("Timeline.initialize() is deprecated and will be removed in future versions")
+#	_event_queue = get_events()
+	return
 
 
+# deprecated
 func event_changed() -> void:
-	emit_changed()
-	property_list_changed_notify()
+	push_warning("Timeline.event_changed() is deprecated and will be removed in future versions")
+#	emit_changed()
+#	property_list_changed_notify()
+	return
 
 
 func set_events(events:Array) -> void:
-	for item in _events:
-		item = item as Resource
-		if item == null:
-			continue
-		if item.is_connected("changed", self, "event_changed"):
-			item.disconnect("changed", self, "event_changed")
-	for item in events:
-		item = item as Resource
-		if not item.is_connected("changed", self, "event_changed"):
-			item.connect("changed", self, "event_changed")
-	_events = events.duplicate()
+	_events = events
 	emit_changed()
 	property_list_changed_notify()
 
@@ -47,15 +49,11 @@ func add_event(event, at_position=-1) -> void:
 		_events.insert(at_position, event)
 	else:
 		_events.append(event)
-	if not event.is_connected("changed", self, "event_changed"):
-		event.connect("changed", self, "event_changed")
 	emit_changed()
 
 
 func erase_event(event) -> void:
 	_events.erase(event)
-	if event.is_connected("changed", self, "event_changed"):
-		event.disconnect("changed", self, "event_changed")
 	emit_changed()
 
 
@@ -92,7 +90,6 @@ func _update_last_n_next_events() -> void:
 
 func _init() -> void:
 	_events = []
-	_event_queue = []
 	resource_name = get_class()
 
 


### PR DESCRIPTION
Having all events contained in a timeline is cool and an easy thing to do.

Things become complicate when you want to make arbitrary jump steps between events, and this is where this PR joins to the scene.

Instead of doing:
```mermaid
flowchart
Timeline --- EventA
Timeline --- EventB
Timeline --- EventC
```
We do now
```mermaid
flowchart
subgraph Timeline
  direction LR
  EventA -->|next event|EventB
  EventB -->|next event|EventC
  end
```