### PR TITLE
Add `tool` in EventEndTimeline.

### DIFF
--- a/addons/event_system_plugin/events/end_timeline.gd
+++ b/addons/event_system_plugin/events/end_timeline.gd
@@ -1,3 +1,4 @@
+tool
 extends Event
 
 func _init() -> void:


### PR DESCRIPTION
EventEndTimeline was not a tool script, making the CategoryManager fail in runtime. This PR fixes that.