### PR TITLE
Verify that next event doesn't make cross references.

### DIFF
--- a/addons/event_system_plugin/resources/event_class/event_class.gd
+++ b/addons/event_system_plugin/resources/event_class/event_class.gd
@@ -76,8 +76,19 @@ func _execute() -> void:
 	finish()
 
 func set_next_event(event:Resource) -> void:
+	if event:
+		var other:Resource = event.get("next_event")
+		if other == self:
+			push_error("Can't cross reference events. Make a new event as pointer and use that instead.")
+			next_event = null
+			emit_changed()
+			property_list_changed_notify()
+			return
+	
 	next_event = event
 	emit_changed()
+	property_list_changed_notify()
+	
 
 
 func get_next_event() -> Resource:


### PR DESCRIPTION
This PR makes tries to help the user when making cross references.

We can't make cross references in Godot (https://github.com/godotengine/godot/issues/21461)