### PR TITLE
Update category_manager.gd

### DIFF
--- a/addons/event_system_plugin/nodes/editor/category_manager.gd
+++ b/addons/event_system_plugin/nodes/editor/category_manager.gd
@@ -71,6 +71,7 @@ var categories:Dictionary = {}
 func reload() -> void:
 	for child in get_children():
 		child.queue_free()
+		categories.clear()
 	create_categories()
 
 


### PR DESCRIPTION
This commits clears the category dictionary when it's reloaded, avoiding to use freed instances