### PR TITLE
Change next event behaviour

### DIFF
--- a/addons/event_system_plugin/core/inspector_tools.gd
+++ b/addons/event_system_plugin/core/inspector_tools.gd
@@ -81,7 +81,26 @@ class InspectorEventSelector extends EditorProperty:
 	
 	
 	func update_property():
-		var event = get_edited_object()[get_edited_property()]
+		var data:Array = str(get_edited_object()[get_edited_property()]).split(";", false)
+		if data.empty():
+			return
+		
+		var event_idx = data[0]
+		var timeline_path = ""
+		if data.size() >= 2:
+			timeline_path = data[1]
+		
+		var timeline = null
+		if timeline_path != "":
+			timeline = load(timeline_path)
+		
+		if not timeline:
+			timeline = Engine.get_meta("EventSystem").timeline_editor._edited_sequence
+		
+		if not timeline:
+			return
+		
+		var event = timeline.get("event/"+event_idx)
 		updating = true
 		if event:
 			event_selector.text = event.get("event_name")
@@ -95,11 +114,11 @@ class InspectorEventSelector extends EditorProperty:
 			popup.call_deferred("popup_centered_ratio", 0.45)
 	
 	
-	func _on_event_selected(event) -> void:
+	func _on_event_selected(event_idx, path) -> void:
 		if updating:
 			return
-		
-		emit_changed(get_edited_property(), event)
+		var value = "{idx};{path}".format({"idx":event_idx, "path":path})
+		emit_changed(get_edited_property(), value)
 	
 	func _on_reset_pressed() -> void:
 		if updating:

--- a/addons/event_system_plugin/events/goto.gd
+++ b/addons/event_system_plugin/events/goto.gd
@@ -3,7 +3,7 @@ extends Event
 class_name EventGoTo
 
 # The next event hint of this event. "<index>;<timeline>"
-export var next_event:String = "" setget set_next_event
+var next_event:String = "" setget set_next_event
 
 func _init() -> void:
 	event_name = "Go to Event"

--- a/addons/event_system_plugin/events/goto.gd
+++ b/addons/event_system_plugin/events/goto.gd
@@ -2,6 +2,9 @@ tool
 extends Event
 class_name EventGoTo
 
+# The next event hint of this event. "<index>;<timeline>"
+var next_event:String = "" setget set_next_event
+
 func _init() -> void:
 	event_name = "Go to Event"
 	event_color = Color("#FBB13C")
@@ -10,3 +13,9 @@ func _init() -> void:
 	continue_at_end = true
 	event_category = "Logic"
 	event_hint = "Helper event to define the next event after this event"
+
+
+func set_next_event(value:String) -> void:
+	next_event = value
+	emit_changed()
+	property_list_changed_notify()

--- a/addons/event_system_plugin/events/goto.gd
+++ b/addons/event_system_plugin/events/goto.gd
@@ -3,7 +3,7 @@ extends Event
 class_name EventGoTo
 
 # The next event hint of this event. "<index>;<timeline>"
-var next_event:String = "" setget set_next_event
+export var next_event:String = "" setget set_next_event
 
 func _init() -> void:
 	event_name = "Go to Event"

--- a/addons/event_system_plugin/events/new_condition.gd
+++ b/addons/event_system_plugin/events/new_condition.gd
@@ -11,15 +11,19 @@ var events_else:String setget _set_else_timeline
 var _events_if:Resource setget set_if_timeline, get_if_timeline
 var _events_else:Resource setget set_else_timeline, get_else_timeline
 
+var next_event
+
 func _execute() -> void:
 	var variables:Dictionary = _Utils.get_property_values_from(get_event_node())
 	
 	var evaluated_condition = _Utils.evaluate(condition, get_event_node(), variables)
 	
 	if evaluated_condition and (str(evaluated_condition) != condition):
-		next_event = get_if_timeline().get("event/0")
+		get_event_manager_node().set("timeline", get_if_timeline())
 	else:
-		next_event = get_else_timeline().get("event/0")
+		get_event_manager_node().set("timeline", get_else_timeline())
+	
+	next_event = "0"
 	
 	finish()
 

--- a/addons/event_system_plugin/nodes/event_manager/event_manager.gd
+++ b/addons/event_system_plugin/nodes/event_manager/event_manager.gd
@@ -49,8 +49,11 @@ func go_to_next_event() -> void:
 				new_timeline = load(new_timeline) as Timeline
 				if new_timeline:
 					timeline = new_timeline
-	else:
-		current_idx += 1
+		else:
+			current_idx += 1
+	
+	if current_idx < 0:
+		current_idx = 0
 	
 	event = timeline.get("event/{idx}".format({"idx":current_idx}))
 	current_event = event
@@ -64,6 +67,7 @@ func go_to_next_event() -> void:
 
 func _execute_event(event:Event) -> void:
 	if event == null:
+		assert(false)
 		return
 	
 	var node:Node = self if event_node_fallback_path == @"." else get_node(event_node_fallback_path)

--- a/addons/event_system_plugin/nodes/event_manager/event_manager.gd
+++ b/addons/event_system_plugin/nodes/event_manager/event_manager.gd
@@ -15,6 +15,7 @@ export(bool) var start_on_ready:bool = false
 
 var timeline
 var current_event
+var current_idx:int = -1
 
 func _ready() -> void:
 	if Engine.editor_hint:
@@ -37,17 +38,26 @@ func start_timeline(timeline_resource:Timeline=timeline) -> void:
 
 func go_to_next_event() -> void:
 	var event
-	if not current_event:
-		if not timeline:
-			_notify_timeline_end()
-			return
-		event = timeline.get("event/0")
-	else:
-		event = current_event.get("next_event")
-		if not event:
-			_notify_timeline_end()
 	
+	if current_event:
+		if "next_event" in current_event and current_event["next_event"] != "":
+			var data = current_event.get("next_event").split(";")
+			current_idx = int(data[0])
+			var new_timeline = data[1]
+			
+			if new_timeline != "":
+				new_timeline = load(new_timeline) as Timeline
+				if new_timeline:
+					timeline = new_timeline
+	else:
+		current_idx += 1
+	
+	event = timeline.get("event/{idx}".format({"idx":current_idx}))
 	current_event = event
+	
+	if current_event == null:
+		_notify_timeline_end()
+		return
 	
 	_execute_event(event)
 

--- a/addons/event_system_plugin/nodes/event_manager/event_manager.gd
+++ b/addons/event_system_plugin/nodes/event_manager/event_manager.gd
@@ -43,7 +43,9 @@ func go_to_next_event() -> void:
 		if "next_event" in current_event and current_event["next_event"] != "":
 			var data = current_event.get("next_event").split(";")
 			current_idx = int(data[0])
-			var new_timeline = data[1]
+			var new_timeline = ""
+			if data.size() > 1:
+				new_timeline = data[1]
 			
 			if new_timeline != "":
 				new_timeline = load(new_timeline) as Timeline

--- a/addons/event_system_plugin/resources/event_class/event_class.gd
+++ b/addons/event_system_plugin/resources/event_class/event_class.gd
@@ -28,8 +28,6 @@ export(bool) var continue_at_end:bool = true setget _set_continue
 
 var event_node_path:NodePath setget _set_event_node_path
 
-var next_event:Resource setget set_next_event, get_next_event
-
 # deprecated. Use get_event_node() instead
 var event_node
 
@@ -79,25 +77,6 @@ func finish() -> void:
 
 func _execute() -> void:
 	finish()
-
-func set_next_event(event:Resource) -> void:
-	if event:
-		var other:Resource = event.get("next_event")
-		if other == self:
-			push_error("Can't cross reference events. Make a new event as pointer and use that instead.")
-			next_event = null
-			emit_changed()
-			property_list_changed_notify()
-			return
-	
-	next_event = event
-	emit_changed()
-	property_list_changed_notify()
-	
-
-
-func get_next_event() -> Resource:
-	return next_event
 
 
 func get_event_name() -> String:

--- a/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
+++ b/addons/event_system_plugin/resources/timeline_class/timeline_class.gd
@@ -99,15 +99,6 @@ func _set(property:String, value) -> bool:
 		else:
 			_events.insert(event_idx, value)
 		
-		var prev_idx:int = event_idx-1
-		
-		if prev_idx > -1:
-			var prev_ev:Resource = _events[prev_idx]
-			var ev_next_pointer:Resource = null
-			if prev_ev:
-				ev_next_pointer = prev_ev.get("next_event")
-				if not ev_next_pointer:
-					prev_ev.set("next_event", value)
 		has_property = true
 		emit_changed()
 	


### PR DESCRIPTION
Previously `next_event` were introduced:
```mermaid
flowchart
subgraph Timeline
  direction LR
  EventA -->|next event|EventB
  EventB -->|next event|EventC
  end
```

The problem is that it was using a resource reference directly. This introduces problems when you want to refer a `next_event` that is externally to the timeline. You can refer to it, but EventManager will not know what will be the next event that it should use.

This PR replaces `next_event` behaviour, making it use index integer, and external references.