### PR TITLE
Fix not being able to select an event in GoTo.

### DIFF
--- a/addons/event_system_plugin/nodes/editor/event_selector/event_selector.tscn
+++ b/addons/event_system_plugin/nodes/editor/event_selector/event_selector.tscn
@@ -1,14 +1,15 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/event_system_plugin/nodes/editor/event_selector/event_selector.gd" type="Script" id=1]
 [ext_resource path="res://addons/event_system_plugin/nodes/editor/timeline_list.gd" type="Script" id=2]
 [ext_resource path="res://addons/event_system_plugin/nodes/editor/timeline_displayer.gd" type="Script" id=3]
+[ext_resource path="res://addons/event_system_plugin/assets/themes/timeline_editor.tres" type="Theme" id=4]
 
 [node name="ConfirmationDialog" type="ConfirmationDialog"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 150, 52.5 )
-popup_exclusive = true
+theme = ExtResource( 4 )
 window_title = "Event Selector"
 script = ExtResource( 1 )
 __meta__ = {

--- a/addons/event_system_plugin/nodes/editor/playground/event_manager_demo.tscn
+++ b/addons/event_system_plugin/nodes/editor/playground/event_manager_demo.tscn
@@ -119,7 +119,7 @@ event_subevents_quantity = 0
 resource_name = "Go to"
 script = ExtResource( 8 )
 continue_at_end = true
-next_event = ""
+next_event = "3;Test timeline"
 event_node_path = NodePath("")
 event_subevents_quantity = 0
 


### PR DESCRIPTION
This fixes an editor issue related to assigned theme to the event selector.

Also makes sure that EditorProperty uses the new timeline format, making
use of the EventManager node instead of trying to get the timeline path
from external paths.

Adds a label under the next event property to show the timeline name.

![image](https://user-images.githubusercontent.com/7025991/181687582-5fd92b19-2c83-4c4d-8ce2-839415f366f6.png)
![image](https://user-images.githubusercontent.com/7025991/181687617-89e979b0-9701-40e3-8882-b21a1386a6bf.png)

Part of the fix for https://github.com/AnidemDex/Godot-EventSystem/issues/61